### PR TITLE
[feature][demo] Add Simple Frequency Domain Visualization

### DIFF
--- a/demo/src/components/App.tsx
+++ b/demo/src/components/App.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../src';
 import { JSONEditor } from './JSONEditor/JSONEditor';
 import { CODEEditor } from './CODEEditor/CODEEditor';
+import { WaveVisualizer } from './WaveVisualizer/WaveVisualizer';
 import styled from 'styled-components';
 import { DemoTheme } from './Theme';
 import { Score } from 'nf-grapher';
@@ -45,7 +46,8 @@ const StyledApplication = styled.div`
 
 enum Panels {
   CODE,
-  JSON
+  JSON,
+  VISUALIZER
 }
 
 const initialAppState = {
@@ -90,15 +92,19 @@ export class App extends React.Component<AppProps, AppState> {
         <VerticalFitArea>
           <VerticalFixedSection>
             <button onClick={() => this.switchPanel(Panels.CODE)}>
-              {panel === Panels.CODE ? '>' : ''} CODE
+              {panel === Panels.CODE && '>'} CODE EDITOR
             </button>
             <button onClick={() => this.switchPanel(Panels.JSON)}>
-              {panel === Panels.JSON ? '>' : ''} JSON
+              {panel === Panels.JSON && '>'} JSON
+            </button>
+            <button onClick={() => this.switchPanel(Panels.VISUALIZER)}>
+              {panel === Panels.VISUALIZER && '>'} VISUALIZER
             </button>
           </VerticalFixedSection>
           <VerticalExpandableSection>
             {panel === Panels.JSON && <JSONEditor player={player} />}
             {panel === Panels.CODE && <CODEEditor player={player} />}
+            {panel === Panels.VISUALIZER && <WaveVisualizer player={player} />}
           </VerticalExpandableSection>
         </VerticalFitArea>
       </StyledApplication>

--- a/demo/src/components/App.tsx
+++ b/demo/src/components/App.tsx
@@ -25,6 +25,8 @@ import {
   TimeInstant,
   ScriptProcessorRenderer
 } from '../../../src';
+import { XAudioContext } from '../../../src/WebAudioContext';
+
 import { JSONEditor } from './JSONEditor/JSONEditor';
 import { CODEEditor } from './CODEEditor/CODEEditor';
 import { WaveVisualizer } from './WaveVisualizer/WaveVisualizer';
@@ -50,9 +52,18 @@ enum Panels {
   VISUALIZER
 }
 
+// https://webaudio.github.io/web-audio-api/#AnalyserNode-attributes
+const defaultAnalyserOptions = {
+  smoothingTimeConstant: 0.8,
+  fftSize: 2048,
+  minDecibels: -100,
+  maxDecibels: -30
+};
+
 const initialAppState = {
   panel: Panels.CODE,
-  player: new SmartPlayer()
+  player: new SmartPlayer(),
+  analyser: XAudioContext().createAnalyser()
 };
 
 type AppState = Readonly<typeof initialAppState>;
@@ -69,15 +80,37 @@ export class App extends React.Component<AppProps, AppState> {
     this.state.player.renderTime = TimeInstant.ZERO;
     this.state.player.setJson(JSON.stringify(new Score()));
 
-    // SmashEditor needs a much smaller quantum in order to
-    // feel responsive when triggering one-shots!
-    const nextRenderer = new ScriptProcessorRenderer(undefined, undefined);
-    const nextPlayer = new SmartPlayer(nextRenderer);
+    let nextRenderer;
+    let analyser;
+    if (to === Panels.VISUALIZER) {
+      const context = XAudioContext();
+      analyser = new AnalyserNode(context, defaultAnalyserOptions);
+      analyser.connect(context.destination);
+      nextRenderer = new ScriptProcessorRenderer(context, undefined);
 
-    this.setState({
+      // FFT analyzer - note that processor is a private property
+      nextRenderer.processor.connect(analyser);
+    } else {
+      // SmashEditor needs a much smaller quantum in order to
+      // feel responsive when triggering one-shots!
+      nextRenderer = new ScriptProcessorRenderer(undefined, undefined);
+    }
+
+    const nextPlayer = new SmartPlayer(nextRenderer);
+    const nextState = {
       panel: to,
       player: nextPlayer
-    });
+    };
+
+    // typescript type guard
+    if (analyser !== undefined) {
+      this.setState({
+        ...nextState,
+        analyser
+      });
+    } else {
+      this.setState(nextState);
+    }
   }
 
   componentDidUpdate() {
@@ -85,7 +118,7 @@ export class App extends React.Component<AppProps, AppState> {
   }
 
   render() {
-    const { panel, player } = this.state;
+    const { panel, player, analyser } = this.state;
 
     return (
       <StyledApplication>
@@ -104,7 +137,9 @@ export class App extends React.Component<AppProps, AppState> {
           <VerticalExpandableSection>
             {panel === Panels.JSON && <JSONEditor player={player} />}
             {panel === Panels.CODE && <CODEEditor player={player} />}
-            {panel === Panels.VISUALIZER && <WaveVisualizer player={player} />}
+            {panel === Panels.VISUALIZER && (
+              <WaveVisualizer player={player} analyser={analyser} />
+            )}
           </VerticalExpandableSection>
         </VerticalFitArea>
       </StyledApplication>

--- a/demo/src/components/WaveVisualizer/FrequencyMonitor.tsx
+++ b/demo/src/components/WaveVisualizer/FrequencyMonitor.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018-Present, Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import { CanvasPowered } from '../ScoreVisualizer/CanvasPowered';
+
+type Props = {
+  frequencies: Uint8Array;
+};
+
+// Frequency values are 8-bit unsigned integers, per AnalyserNode.getByteFrequencyData();
+const scalingDenominator = 1 / 255; // denominator is maximum value, 2^8 -1
+const barColor = '#000000';
+
+export class FrequencyMonitor extends React.Component<Props> {
+  drawParamValues = (cvs: HTMLCanvasElement, ctx: CanvasRenderingContext2D) => {
+    const { frequencies } = this.props;
+
+    ctx.clearRect(0, 0, cvs.width, cvs.height);
+    const canvasHeight = cvs.height;
+    const canvasWidth = cvs.width;
+    const binCount = frequencies.length;
+    const barWidth = canvasWidth / binCount;
+    ctx.fillStyle = barColor;
+
+    for (let i = 0; i < binCount; i++) {
+      const percent = frequencies[i] * scalingDenominator;
+      const height = canvasHeight * percent;
+      const offset = canvasHeight - height - 1;
+      ctx.fillRect(i * barWidth, offset, barWidth, height);
+    }
+  };
+
+  render() {
+    return (
+      <CanvasPowered autofit="width" width={200} height={400}>
+        {this.drawParamValues}
+      </CanvasPowered>
+    );
+  }
+}

--- a/demo/src/components/WaveVisualizer/WaveVisualizer.tsx
+++ b/demo/src/components/WaveVisualizer/WaveVisualizer.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2018-Present, Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+import { SmartPlayer, TimeInstant } from '../../../../src';
+import { examples, ExampleJSON } from '../../ExampleJSONScores';
+
+import { MonacoEditor } from '../Monaco';
+import { PlayerControlBar } from '../PlayerControlBar';
+import { PlayerWatcher } from '../PlayerWatcher';
+import { Score, TypedNode } from 'nf-grapher';
+import { ScoreVisualizer } from '../ScoreVisualizer';
+import {
+  VerticalFitArea,
+  VerticalFixedSection,
+  VerticalExpandableSection
+} from '../VerticalLayout';
+
+// Nodes within Grapher Scores are of type Node and are a 1:1 with their JSON
+// serialization. But if you call Score.from(obj) the nodes are "parsed" into
+// a TypedNode. This is a gotcha.
+const extractTypedNodes = (score: Score) =>
+  Score.from(score).graph.nodes as TypedNode[];
+
+type Props = {
+  player: SmartPlayer;
+};
+
+const initialState = {
+  example: examples[0],
+  exampleTypedNodes: extractTypedNodes(examples[0].score),
+  loading: false
+};
+
+type State = Readonly<{
+  example: undefined | ExampleJSON;
+  exampleTypedNodes: TypedNode[];
+  loading: boolean;
+}>;
+
+export class WaveVisualizer extends React.Component<Props, State> {
+  readonly state = initialState;
+
+  private getEditorValue: () => string = () => '';
+
+  onExampleSelect = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const example = examples.find(
+      example => example.name === event.target.value
+    );
+
+    this.setState({
+      example: example,
+      exampleTypedNodes: example ? extractTypedNodes(example.score) : []
+    });
+
+    const { player } = this.props;
+
+    if (player.playing) {
+      player.playing = false;
+    }
+  };
+
+  handlePlayPause = async () => {
+    const { player } = this.props;
+
+    if (player.playing) {
+      player.playing = false;
+      return;
+    }
+
+    try {
+      const editorValue: Score = JSON.parse(this.getEditorValue());
+      const playerValue: Score[] = JSON.parse(player.getJson());
+
+      const editorJSON = JSON.stringify(editorValue);
+      const playerJSON = JSON.stringify(playerValue[0]);
+      const exampleJSON = JSON.stringify(this.state.example.score);
+
+      // We only want to reload the graph if the Score is actually different.
+      if (!playerValue.length || editorJSON !== playerJSON) {
+        // The editor value is the source of true, send it into the player.
+        this.setState({ loading: true });
+        await player.setJson(editorJSON);
+
+        // We need these to visualize the score.
+        const exampleTypedNodes = extractTypedNodes(editorValue);
+
+        // Only set the internal state to "user edited" if the current JSON is
+        // likely user-edited.
+        if (editorJSON !== exampleJSON) {
+          this.setState({
+            example: {
+              name: 'User edited',
+              score: editorValue
+            }
+          });
+        }
+
+        this.setState({ loading: false, exampleTypedNodes });
+      }
+    } catch (e) {}
+
+    player.playing = !player.playing;
+  };
+
+  render() {
+    const { player } = this.props;
+    const { example, loading, exampleTypedNodes } = this.state;
+
+    return (
+      <VerticalFitArea>
+        <VerticalFixedSection>
+          <label>
+            Examples:
+            <select
+              onChange={this.onExampleSelect}
+              value={example ? example.name : undefined}
+            >
+              {examples.map(example => (
+                <option key={example.name} value={example.name}>
+                  {example.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <PlayerWatcher player={player}>
+            {(currentTime, playing) => (
+              <PlayerControlBar
+                currentTime={currentTime}
+                isPlaying={playing}
+                isLoading={loading}
+                onPlayPause={this.handlePlayPause}
+                onSeek={amount => {
+                  const total = player.renderTime.add(amount);
+                  player.renderTime = total.lt(TimeInstant.ZERO)
+                    ? TimeInstant.ZERO
+                    : total;
+                }}
+              />
+            )}
+          </PlayerWatcher>
+        </VerticalFixedSection>
+        <VerticalExpandableSection>
+          <PlayerWatcher player={player}>
+            {(currentTime, playing) =>
+              playing ? (
+                <ScoreVisualizer
+                  nodes={exampleTypedNodes}
+                  descriptions={player.getPlaybackDescription(currentTime)}
+                />
+              ) : (
+                <MonacoEditor
+                  language={'json'}
+                  value={
+                    example ? JSON.stringify(example.score, null, '  ') : ''
+                  }
+                  valueDelegate={getValue => (this.getEditorValue = getValue)}
+                />
+              )
+            }
+          </PlayerWatcher>
+        </VerticalExpandableSection>
+      </VerticalFitArea>
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This adds a basic example for using the WebAudio `AnalyserNode` API along with Canvas to visualize real-time audio playback frequency. 

![Screen Recording 2019-04-13 at 09 06 PM](https://user-images.githubusercontent.com/9020979/56086986-14af8880-5e30-11e9-9a2f-e3df258102fd.gif) ([link](https://cl.ly/901690054b68))

Made possible by the guidance from @kirbysayshi in [this comment](https://github.com/spotify/NFPlayerJS/issues/10#issuecomment-480654136) in #10, along with this demo: [WebAudioAPI](https://webaudioapi.com/samples/visualizer/)

## Note on Architecture

I aimed to keep the example as small/contained as possible, but felt that putting the analyser up in `App.tsx` was necessary since that's where new `SmartPlayers` are made. However, I could contain the new SmartPlayer to just the `WaveVisualizer.tsx` instead, and ignore the one that is passed in.

I could have based this component on the Code Editor instead, but went with JSON editor to avoid the risk of someone forgetting to click `Eval`. 

*Unrelated Question*

Is there a fast way to go from "song term" search to "spotify preview URL"? I swapped out Roxanne during testing using the [web api](https://developer.spotify.com/console/get-track/) to find some alternative tracks, but was wondering if there was an existing GUI I could use.
