### PR TITLE
fix: Fix `ScriptProcessorNode` buffer size

### DIFF
--- a/src/renderers/BaseRenderer.ts
+++ b/src/renderers/BaseRenderer.ts
@@ -53,7 +53,7 @@ export const enum PlayingState {
 }
 
 export class BaseRenderer {
-  // Minimum is 256 for ScriptProcessorNode!
+  // Minimum is 0 for ScriptProcessorNode!
   static DEFAULT_QUANTUM_SIZE = 8192;
 
   protected samplesElapsed: number = 0;

--- a/src/renderers/ScriptProcessorRenderer.ts
+++ b/src/renderers/ScriptProcessorRenderer.ts
@@ -41,8 +41,8 @@ export class ScriptProcessorRenderer extends BaseRenderer {
       {
         channelCount: ctx.destination.channelCount,
         sampleRate: ctx.sampleRate,
-        // ScriptProcessorNode only accepts 256 - 8192.
-        quantumSize: Math.min(Math.max(quantumSize, 256), 8192),
+        // ScriptProcessorNode only accepts 0 - 16384.
+        quantumSize: Math.min(Math.max(quantumSize, 0), 16384),
         decode: (uri, ab: ArrayBuffer) =>
           new Promise<XAudioBuffer>((resolve, reject) => {
             dbg('decoding file %s', uri);


### PR DESCRIPTION
`ScriptProcessorNode` [buffer size](https://www.w3.org/TR/webaudio/#dom-scriptprocessornode-buffersize) is one of 256, 512, 1024, 2048, 4096, 8912, 16384 or 0.

> The ScriptProcessorNode is constructed with a bufferSize which MUST be one of the following values: 256, 512, 1024, 2048, 4096, 8192, 16384.

> This value will be picked by the implementation if the bufferSize argument to createScriptProcessor() is not passed in, or is set to 0.



