### PR TITLE
fix: use `Float32Array` instead of number array

### DIFF
--- a/demo/nf-grapher.d.ts
+++ b/demo/nf-grapher.d.ts
@@ -179,7 +179,7 @@ export declare class AudioParam extends TypedParam<number> {
    * Specifies a curve to render based on the given float values.
    */
   setValueCurveAtTime(
-    values: number[],
+    values: Float32Array,
     startTime: number,
     duration: number
   ): AudioParam;

--- a/demo/nf-player.d.ts
+++ b/demo/nf-player.d.ts
@@ -94,7 +94,7 @@ declare class PseudoAudioParam {
     timeConstant: number
   ): PseudoAudioParam;
   setValueCurveAtTime(
-    values: number[],
+    values: Float32Array,
     time: number,
     duration: number
   ): PseudoAudioParam;
@@ -146,7 +146,7 @@ export interface SetTargetAtTimeCmd {
 export interface SetValueCurveAtTimeCmd {
   name: 'setValueCurveAtTime';
   args: {
-    values: number[];
+    values: Float32Array;
     startTime: number;
     duration: number;
   };


### PR DESCRIPTION
[The 1st argument](https://www.w3.org/TR/webaudio/#dom-audioparam-setvaluecurveattime) of `setValueCurveAtTime` is `Float32Array` (`sequence<float>`)